### PR TITLE
Use a shared, rate-limited http client

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,5 +1,7 @@
 DB_URL=postgres://aubonmeeple:aubonmeeple@127.0.0.1/aubonmeeple
 RUST_LOG_STYLE=auto
-RUST_LOG=trace
+RUST_LOG=warn,boardgame_finder=debug,backend=debug,frontend=debug
 
 FRONTEND_LISTEN_PORT=3001
+
+RATELIMIT_PER_MINUTE=30

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,12 +200,14 @@ dependencies = [
  "env_logger",
  "feed-rs",
  "futures-util",
+ "governor",
  "hyper",
  "hyper-tls",
  "image",
  "lazy_static",
  "log",
  "log-panics",
+ "nonzero_ext",
  "prometheus",
  "rand",
  "regex",
@@ -494,6 +496,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.3",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,6 +769,7 @@ checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -775,6 +791,17 @@ name = "futures-core"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -806,15 +833,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
 name = "futures-util"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -897,6 +933,24 @@ dependencies = [
  "bitflags 1.3.2",
  "ignore",
  "walkdir",
+]
+
+[[package]]
+name = "governor"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "821239e5672ff23e2a7060901fa622950bbd80b649cdaadd78d1c1767ed14eb4"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures",
+ "futures-timer",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot",
+ "quanta",
+ "rand",
+ "smallvec",
 ]
 
 [[package]]
@@ -1291,6 +1345,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "mach2"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1409,6 +1472,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1417,6 +1486,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "nu-ansi-term"
@@ -1850,6 +1925,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17e662a7a8291a865152364c20c7abc5e60486ab2001e8ec10b24862de0b9ab"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "mach2",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1906,6 +1997,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "10.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,10 @@ path = "src/bin/frontend/main.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+nonzero_ext = "0.3"
 feed-rs = "1.3.0"
-reqwest = "*"
+reqwest = "0.11"
+governor = "0.6"
 rss = "2.0.4"
 regex = "*"
 bytes = "*"

--- a/src/bin/backend/crawler.rs
+++ b/src/bin/backend/crawler.rs
@@ -1,7 +1,5 @@
 use lazy_static::lazy_static;
 use prometheus::{register_int_counter, IntCounter};
-use std::time::Duration;
-use tokio::time;
 
 use boardgame_finder::db::{
     connect_db, insert_announce_into_db, select_game_with_id_from_db, update_game_from_db,
@@ -14,8 +12,6 @@ pub async fn start_crawler() {
     log::info!("starting crawler thread");
 
     let db_client = connect_db().await.unwrap();
-
-    let mut interval_stream = time::interval(Duration::from_secs(20));
 
     let mut page = 1;
     loop {
@@ -54,7 +50,6 @@ pub async fn start_crawler() {
                             }
                         }
                     }
-                    interval_stream.tick().await;
                 }
             }
         }

--- a/src/bin/backend/gamechecker.rs
+++ b/src/bin/backend/gamechecker.rs
@@ -1,6 +1,5 @@
 use chrono::Duration;
 use lazy_static::lazy_static;
-use rand::Rng;
 
 use boardgame_finder::db::{
     connect_db, delete_from_all_table_with_id, select_intervalled_ids_from_oa_table_from_db,
@@ -49,11 +48,6 @@ pub async fn task(start_date_offset: Duration, duration: Duration) {
                     log::error!("error deleting from db : {}", e);
                 }
             }
-            let sleep_duration = {
-                let mut rng = rand::thread_rng();
-                Duration::seconds(rng.gen_range(5..=10))
-            };
-            tokio::time::sleep(sleep_duration.to_std().unwrap()).await;
         }
 
         let loop_duration = chrono::Utc::now() - start_loop_time;

--- a/src/bin/backend/main.rs
+++ b/src/bin/backend/main.rs
@@ -16,7 +16,6 @@ use lazy_static::lazy_static;
 use prometheus::{register_int_counter, Encoder, IntCounter, TextEncoder};
 use std::collections::HashMap;
 use std::error;
-use std::error::Error;
 use std::time::{Duration, Instant};
 use tokio::task::JoinSet;
 use tokio::time;
@@ -292,7 +291,7 @@ async fn set_server() {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn Error + 'static>> {
+async fn main() {
     log_panics::init();
 
     std::panic::set_hook(Box::new(|panic_info| {

--- a/src/httpclient.rs
+++ b/src/httpclient.rs
@@ -1,0 +1,29 @@
+use hyper::StatusCode;
+use reqwest::{Client, ClientBuilder, IntoUrl, Response};
+use scraper::Html;
+
+lazy_static::lazy_static! {
+    static ref CLIENT: Client = create_client();
+}
+
+fn create_client() -> Client {
+    ClientBuilder::new()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .expect("Failed to build reqwest::Client")
+}
+
+/// Execute a request using the shared http client
+pub async fn get<U: IntoUrl>(url: U) -> Result<Response, reqwest::Error> {
+   CLIENT.get(url).send().await
+}
+
+/// Fetch an HTML document from a URL
+pub async fn get_doc<U: IntoUrl>(url: U) -> Result<(Html, StatusCode), reqwest::Error> {
+    let response = CLIENT.get(url).send().await?;
+    let http_code = response.status();
+
+    let content = response.text().await?;
+    let document = Html::parse_document(&content);
+    Ok((document, http_code))
+}

--- a/src/httpclient.rs
+++ b/src/httpclient.rs
@@ -1,9 +1,18 @@
+use std::num::NonZeroU32;
 use hyper::StatusCode;
 use reqwest::{Client, ClientBuilder, IntoUrl, Response};
 use scraper::Html;
+use governor::{Quota, RateLimiter, DefaultKeyedRateLimiter, clock};
+use governor::state::keyed::DefaultKeyedStateStore;
+use nonzero_ext::nonzero;
+
+/// DEFAULT_QUOTA is the default requests per minutes if not specified
+const DEFAULT_QUOTA: Quota = Quota::per_minute(nonzero!(30u32));
 
 lazy_static::lazy_static! {
     static ref CLIENT: Client = create_client();
+    static ref LIMITER_CLOCK: clock::DefaultClock = clock::DefaultClock::default();
+    static ref LIMITER: DefaultKeyedRateLimiter<String> = create_limiter();
 }
 
 fn create_client() -> Client {
@@ -13,14 +22,39 @@ fn create_client() -> Client {
         .expect("Failed to build reqwest::Client")
 }
 
+fn create_limiter() -> DefaultKeyedRateLimiter<String> {
+    let quota = std::env::var("RATELIMIT_PER_MINUTE")
+        .map_err(|v| v.to_string())
+        .and_then(|v| v.parse::<u32>().map_err(|v| v.to_string()))
+        .and_then(|v| NonZeroU32::new(v).ok_or_else(|| "Cannot convert to non-zero u32".to_string()))
+        .map(Quota::per_minute)
+        .unwrap_or_else(|err| {
+            log::warn!("Cannot initialize quota from environment, fallback to default: {}", err);
+            DEFAULT_QUOTA
+        })
+        .allow_burst(nonzero!(1u32));
+
+    log::debug!("Creating rate limiter with quota {:?}", quota);
+    let state = DefaultKeyedStateStore::default();
+    RateLimiter::new(quota, state, &LIMITER_CLOCK)
+}
+
+
 /// Execute a request using the shared http client
 pub async fn get<U: IntoUrl>(url: U) -> Result<Response, reqwest::Error> {
-   CLIENT.get(url).send().await
+    let url_r = url.into_url()?;
+
+    let ratelimit_key = url_r.host_str().unwrap().to_string();
+    log::debug!("get_doc {}", url_r);
+    LIMITER.until_key_ready(&ratelimit_key).await;
+
+    CLIENT.get(url_r).send().await
 }
 
 /// Fetch an HTML document from a URL
+/// The requests are rate-limited by host
 pub async fn get_doc<U: IntoUrl>(url: U) -> Result<(Html, StatusCode), reqwest::Error> {
-    let response = CLIENT.get(url).send().await?;
+    let response = get(url).await?;
     let http_code = response.status();
 
     let content = response.text().await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,4 @@ pub mod db;
 pub mod frontlib;
 pub mod game;
 pub mod website;
+pub mod httpclient;

--- a/src/website/knapix.rs
+++ b/src/website/knapix.rs
@@ -1,11 +1,8 @@
 use std::error;
 
-use scraper::{Html, Selector};
+use scraper::Selector;
 
-use crate::{
-    game::{Game, Reference},
-    website::helper::clean_name,
-};
+use crate::{game::{Game, Reference}, httpclient, website::helper::clean_name};
 
 pub async fn get_knapix_prices(game: &mut Game) -> Result<(), Box<dyn error::Error>> {
     let name = clean_name(&game.okkazeo_announce.name).replace(' ', "+");
@@ -15,8 +12,7 @@ pub async fn get_knapix_prices(game: &mut Game) -> Result<(), Box<dyn error::Err
     );
 
     log::debug!("searching knapix {}", search);
-    let content = reqwest::get(search).await?.bytes().await?;
-    let document = Html::parse_document(std::str::from_utf8(&content)?);
+    let (document, _) = httpclient::get_doc(search).await?;
 
     // choper <tr data-href="/r/127347999"> pou rla redirection vers le site
     let row_selector = Selector::parse("tr[data-href]")?;

--- a/src/website/ludifolie.rs
+++ b/src/website/ludifolie.rs
@@ -1,6 +1,7 @@
 use scraper::{Html, Selector};
 
 use crate::website::helper::are_names_similar;
+use crate::httpclient;
 
 pub async fn get_ludifolie_price_and_url_by_name(
     name: &str,
@@ -16,10 +17,10 @@ pub async fn get_ludifolie_price_and_url_by_name(
         name_clean
     );
 
-    let content = reqwest::get(&search).await?.bytes().await?;
+    let (doc, _) = httpclient::get_doc(&search).await?;
     Ok(parse_ludifolie_document(
         name,
-        std::str::from_utf8(&content)?,
+        &doc,
     ))
 }
 
@@ -27,9 +28,7 @@ fn normalize_ludifolie_name(name: &str) -> String {
     name.replace('&', " ")
 }
 
-fn parse_ludifolie_document(name: &str, doc: &str) -> Option<(f32, String)> {
-    let document = Html::parse_document(doc);
-
+fn parse_ludifolie_document(name: &str, document: &Html) -> Option<(f32, String)> {
     let product_selector = Selector::parse(".product-miniature-wrapper").unwrap();
     let href_selector = Selector::parse(".product-title a").unwrap();
     let price_selector = Selector::parse(".product-price-and-shipping .price").unwrap();

--- a/src/website/ludocortex.rs
+++ b/src/website/ludocortex.rs
@@ -1,14 +1,13 @@
-use scraper::{Html, Selector};
+use scraper::Selector;
 
-use crate::website::helper::{are_names_similar, clean_name};
+use crate::{httpclient, website::helper::{are_names_similar, clean_name}};
 
 pub async fn get_ludocortex_price_and_url_by_barcode(
     barcode: u64,
 ) -> Result<Option<(f32, String)>, anyhow::Error> {
     let search = format!("https://www.ludocortex.fr/jolisearch?s={}", barcode);
     log::debug!("search on ludocortex by barcode: {}", barcode);
-    let content = reqwest::get(&search).await?.bytes().await?;
-    let document = Html::parse_document(std::str::from_utf8(&content)?);
+    let (document, _) = httpclient::get_doc(&search).await?;
 
     // Sélecteur pour l'article de produit
     let product_selector = Selector::parse(".product-miniature").unwrap();
@@ -64,8 +63,7 @@ pub async fn get_ludocortex_price_and_url_by_name(
     );
     log::debug!("search on ludocortex by name: {}", &name);
 
-    let content = reqwest::get(&search).await?.bytes().await?;
-    let document = Html::parse_document(std::str::from_utf8(&content)?);
+    let (document, _) = httpclient::get_doc(&search).await?;
 
     // Sélecteur pour l'article de produit
     let product_selector = Selector::parse(".product-miniature").unwrap();

--- a/src/website/philibert.rs
+++ b/src/website/philibert.rs
@@ -1,6 +1,6 @@
-use scraper::{Html, Selector};
+use scraper::Selector;
 
-use crate::website::helper::{are_names_similar, clean_name};
+use crate::{httpclient, website::helper::{are_names_similar, clean_name}};
 
 pub async fn get_philibert_price_and_url_by_barcode(
     barcode: u64,
@@ -10,8 +10,7 @@ pub async fn get_philibert_price_and_url_by_barcode(
         barcode
     );
     log::debug!("search on philibert by barcode: {}", &barcode);
-    let content = reqwest::get(&search).await?.bytes().await?;
-    let document = Html::parse_document(std::str::from_utf8(&content)?);
+    let (document, _) = httpclient::get_doc(&search).await?;
 
     let product_list_selector = Selector::parse(".product_list.grid .ajax_block_product").unwrap();
     let price_selector = Selector::parse(".price").unwrap();
@@ -56,8 +55,7 @@ pub async fn get_philibert_price_and_url_by_name(
         clean_name(name)
     );
     log::debug!("search on philibert by name: {}", &name);
-    let content = reqwest::get(&search).await?.bytes().await?;
-    let document = Html::parse_document(std::str::from_utf8(&content)?);
+    let (document, _) = httpclient::get_doc(&search).await?;
 
     let product_list_selector = Selector::parse(".product_list.grid .ajax_block_product").unwrap();
     let price_selector = Selector::parse(".price").unwrap();

--- a/src/website/ultrajeux.rs
+++ b/src/website/ultrajeux.rs
@@ -10,7 +10,7 @@ pub async fn get_ultrajeux_price_and_url_by_barcode(
         barcode
     );
     log::debug!("search on ultrajeux by barcode: {}", barcode);
-    let content = reqwest::get(&search).await?.bytes().await?;
+    let content = httpclient::get(&search).await?.bytes().await?;
     let re = Regex::new(r#"produit_prix.*?class="prix.*?([\d,]+) "#).unwrap();
     let content_str: &str = &String::from_utf8_lossy(&content);
     for capture in re.captures_iter(content_str) {
@@ -32,7 +32,7 @@ pub async fn get_ultrajeux_price_and_url_by_name(
         clean_name(name)
     );
     log::debug!("search on ultrajeux by name: {}", name);
-    let content = reqwest::get(&search).await?.bytes().await?;
+    let content = httpclient::get(&search).await?.bytes().await?;
     let re = Regex::new(r#"produit_prix.*?class="prix.*?([\d,]+) "#).unwrap();
     let content_str: &str = &String::from_utf8_lossy(&content);
     for capture in re.captures_iter(content_str) {
@@ -60,6 +60,7 @@ pub async fn get_ultrajeux_price_and_url(
 
 use lazy_static::lazy_static;
 use prometheus::{register_int_counter_vec, IntCounterVec};
+use crate::httpclient;
 lazy_static! {
     static ref ULTRAJEUX_STAT: IntCounterVec = register_int_counter_vec!(
         "ultrajeux_stat",


### PR DESCRIPTION
Remove manual delay between scapes. Instead uses a single shared http client with a configurable rate-limit.